### PR TITLE
revisions to initial margo instructions

### DIFF
--- a/docs/source/tutorials/01_setup.rst
+++ b/docs/source/tutorials/01_setup.rst
@@ -24,7 +24,7 @@ Option 1 (preferred): create a development environment using Docker
 .. note::
 
    The Docker instructions here rely on a pre-built container image that was
-   built for x86_64 platforms.  If you host machine has a different CPU
+   built for x86_64 platforms.  If your host machine has a different CPU
    architecture (for example, an Apple M1) then you may need to create your own image from scratch to ensure that the tutorial environment works correctly.
    Please see the `instructions for building a Docker image from scratch
    <https://github.com/mochi-hpc-experiments/mochi-docker/tree/main/mochi-tutorial#option-2-building-your-own-image>`_

--- a/docs/source/tutorials/01_setup.rst
+++ b/docs/source/tutorials/01_setup.rst
@@ -32,8 +32,8 @@ Option 1 (preferred): create a development environment using Docker
    architecture.
 
    If you are not sure about your host CPU architecture, one symptom of
-   using a mismatched image is a `WARNING: The requested image's platform does
-   not match the detected host platform` message when you run the `docker
+   using a mismatched image is a :code:`WARNING: The requested image's platform does
+   not match the detected host platform` message when you run the :code:`docker
    run` command below.
 
 You need to first have Docker installed on your machine;

--- a/docs/source/tutorials/01_setup.rst
+++ b/docs/source/tutorials/01_setup.rst
@@ -21,6 +21,21 @@ native environment, please skip to **Option 2**.
 Option 1 (preferred): create a development environment using Docker
 -------------------------------------------------------------------
 
+.. note::
+
+   The Docker instructions here rely on a pre-built container image that was
+   built for x86_64 platforms.  If you host machine has a different CPU
+   architecture (for example, an Apple M1) then you may need to create your own image from scratch to ensure that the tutorial environment works correctly.
+   Please see the `instructions for building a Docker image from scratch
+   <https://github.com/mochi-hpc-experiments/mochi-docker/tree/main/mochi-tutorial#option-2-building-your-own-image>`_
+   for more information on how to build an image appropriate for your
+   architecture.
+
+   If you are not sure about your host CPU architecture, one symptom of
+   using a mismatched image is a `WARNING: The requested image's platform does
+   not match the detected host platform` message when you run the `docker
+   run` command below.
+
 You need to first have Docker installed on your machine;
 please see the `Docker installation instructions for your platform <https://docs.docker.com/get-docker/>`_.
 Once Docker is installed, you can use the following commands to download a preconfigured image:
@@ -69,6 +84,7 @@ tutorial exercise files.
 
    mochi@d3c9c489a2c1:~$ ls mochi-tutorial
    margo-tutorial-exercises
+   thallium-tutorial-exercises
 
 We recommand that you open multiple shells while following these exercises,
 so that you can build the code, run a server and run a client in different terminals

--- a/docs/source/tutorials/margo/01_ex1.rst
+++ b/docs/source/tutorials/margo/01_ex1.rst
@@ -60,7 +60,7 @@ For the client:
 
 .. code-block:: console
 
-   src/client na+sm <server-address>
+   src/client <server-address>
 
 Copy :code:`<server-address>` from the standard output of the server command.
 The server is setup to run indefinitely. You may kill it with Ctrl-C.
@@ -76,20 +76,52 @@ The server is setup to run indefinitely. You may kill it with Ctrl-C.
    it to the client, other your shell will interpret the semicolumn as the
    end of your command.
 
-|cbox| Looking at the API in :code:`phonebook.h`, edit :code:`server.c` to add the
-creation of a phonebook object and its destruction when the server terminates.
-This phonebook should be added as a field to the :code:`server_data` structure
-and to the :code:`svr_data` instance (see comments **(1)** to **(3)** in
-:code:`server.c`). This instance is attached to RPCs using :code:`margo_register_data`
-so the phonebook can be accessed inside RPCs.
+Now inspect the server.c file.  One important data structure to take note of
+is the `server_data` struct.  It contains the state of the example service.
+Anything added to this structure will be maintained across the lifetime of
+the service and can (optionally) be manipulated by via RPCs.  This is where
+we will maintain the phonebook data structure for this hands-on exercise.
 
-|cbox| Our two RPCs, which we will call "insert" and "lookup", will need argument
-and return types. Edit the :code:`types.h` file to add the necessary type definitions
+You an also see that individual RPCs are registered using the
+`MARGO_REGISTER()` macro, as in the "sum" example.  Note that this example
+also calls the `margo_register_data()` function immediately after the RPC is
+registered.  The purpose of `margo_register_data()` is to associate state
+(in this case the `server_data` struct instance) with RPCs so that RPC
+handlers can retrieve that pointer later without relying on a global
+variable.  This convention makes it safe for a server daemon to run multiple
+copies of the same provider without interfering with each other.  Any new
+RPCs we add that manipulate the phonebook state will similarly need to
+register that data pointer.
+
+|cbox| Look at the API in :code:`phonebook.h`.  This is a local API for
+manipulating a phonebook data structure.  Your task now is to add new RPCs
+to the server that will allow
+remote clients to manipulate a phonebook as well.  You will need to include
+`phonebook.h` in server.c so that the service has access to the phonebook API.   Next you must initiate a single phonebook instance for the service to maintain.  Edit :code:`server.c` to add the creation of a phonebook
+object (i.e., a call to `phonebook_new()`) and its destruction (i.e., a call
+to `phonebook_delete()`) when the server terminates.  This phonebook should
+be added as a field to the :code:`server_data` structure and to the
+:code:`svr_data` instance (see comments **(1)** to **(3)** in
+:code:`server.c`).
+
+|cbox| Your next task is to add two new RPCs, which we will call "insert" and "lookup".  Begin by defining their input and output argument types.  This is done using `MERCURY_GEN_PROC()` macros of the following form:
+
+.. code-block:: c
+
+   MERCURY_GEN_PROC(rpc_name,
+      ((type)(arg1))\
+      ((type)(arg2))\
+      ...
+      ((type)(argN)))
+
+Edit the :code:`types.h` file to add the necessary type definitions
 for these RPCs (:code:`insert_in_t`, :code:`insert_out_t`, :code:`lookup_in_t`
 and :code:`lookup_out_t`, see comment **(4)**). Do so using the Mercury macros,
 following the model of the :code:`sum_in_t` and :code:`sum_out_t` types.
+Recall that we will use a uint64_t type to represent phone numbers.
+
 *Hint: Mercury represents null-terminated strings with the type :code:`hg_string_t`,
-whose serialization routines are defined in the :code:`mercury_proc_string.h` header.*
+whose serialization routines are defined in the :code:`mercury_proc_string.h` header.  You must include this header in types.h to gain access to this type definition.*
 
 .. note::
 

--- a/docs/source/tutorials/margo/01_ex1.rst
+++ b/docs/source/tutorials/margo/01_ex1.rst
@@ -77,16 +77,16 @@ The server is setup to run indefinitely. You may kill it with Ctrl-C.
    end of your command.
 
 Now inspect the server.c file.  One important data structure to take note of
-is the `server_data` struct.  It contains the state of the example service.
+is the :code:`server_data` struct.  It contains the state of the example service.
 Anything added to this structure will be maintained across the lifetime of
 the service and can (optionally) be manipulated by via RPCs.  This is where
 we will maintain the phonebook data structure for this hands-on exercise.
 
 You an also see that individual RPCs are registered using the
-`MARGO_REGISTER()` macro, as in the "sum" example.  Note that this example
-also calls the `margo_register_data()` function immediately after the RPC is
-registered.  The purpose of `margo_register_data()` is to associate state
-(in this case the `server_data` struct instance) with RPCs so that RPC
+:code:`MARGO_REGISTER()` macro, as in the "sum" example.  Note that this example
+also calls the :code:`margo_register_data()` function immediately after the RPC is
+registered.  The purpose of :code:`margo_register_data()` is to associate state
+(in this case the :code:`server_data` struct instance) with RPCs so that RPC
 handlers can retrieve that pointer later without relying on a global
 variable.  This convention makes it safe for a server daemon to run multiple
 copies of the same provider without interfering with each other.  Any new
@@ -97,9 +97,9 @@ register that data pointer.
 manipulating a phonebook data structure.  Your task now is to add new RPCs
 to the server that will allow
 remote clients to manipulate a phonebook as well.  You will need to include
-`phonebook.h` in server.c so that the service has access to the phonebook API.   Next you must initiate a single phonebook instance for the service to maintain.  Edit :code:`server.c` to add the creation of a phonebook
-object (i.e., a call to `phonebook_new()`) and its destruction (i.e., a call
-to `phonebook_delete()`) when the server terminates.  This phonebook should
+:code:`phonebook.h` in server.c so that the service has access to the phonebook API.   Next you must initiate a single phonebook instance for the service to maintain.  Edit :code:`server.c` to add the creation of a phonebook
+object (i.e., a call to :code:`phonebook_new()`) and its destruction (i.e., a call
+to :code:`phonebook_delete()`) when the server terminates.  This phonebook should
 be added as a field to the :code:`server_data` structure and to the
 :code:`svr_data` instance (see comments **(1)** to **(3)** in
 :code:`server.c`).


### PR DESCRIPTION
- add note about how to deal with mismatched docker architectures
- fix typo (extra argument to client in initial example)
- add some more explanation and hints to early exercise steps